### PR TITLE
Add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "var",
     "variable"
   ],
+  "repository": "matthewmueller/envobj",
   "author": "Matthew Mueller",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
This field allows to quickly jump to the sources from npm website and CLI.

See more at https://docs.npmjs.com/files/package.json#repository