### PR TITLE
More advanced TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,15 @@
-declare function envobj <T> (config: T): envobj.Result<T>
-declare function envobj <T> (config: envobj.Config<T>): T
+declare function envobj <T extends envobj.ValidConfig> (config: T): envobj.Result<T>
+declare function envobj <T extends envobj.ValidResult> (config: envobj.Config<T>): T
 
 declare namespace envobj {
+  interface ValidConfig {
+    [key: string]: string | typeof String | number | typeof Number | boolean | typeof Boolean
+  }
+
+  interface ValidResult {
+    [key: string]: string | number | boolean
+  }
+
   type Config <T> = {
     [K in keyof T]: T[K] extends string
       ? (string | typeof String) : T[K] extends number

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,19 @@
+declare function envobj <T> (config: T): envobj.Result<T>
 declare function envobj <T> (config: envobj.Config<T>): T
 
 declare namespace envobj {
   type Config <T> = {
-    [K in keyof T]: string | number | boolean | typeof Number | typeof String | typeof Boolean
+    [K in keyof T]: T[K] extends string
+      ? (string | typeof String) : T[K] extends number
+      ? (number | typeof Number) : T[K] extends boolean
+      ? (boolean | typeof Boolean) : never
+  }
+
+  type Result <T> = {
+    [K in keyof T]: T[K] extends string | typeof String
+      ? string : T[K] extends number | typeof Number
+      ? number : T[K] extends boolean | typeof Boolean
+      ? boolean : never
   }
 }
 


### PR DESCRIPTION
[TypeScript 2.8](https://blogs.msdn.microsoft.com/typescript/2018/03/27/announcing-typescript-2-8/#conditional-types) recently landed with conditional types and it enables full type checking of `envobj` now! No more union between the possible types and requiring you to specify `T`. Now it'll _just_ understand things like:

```js
envobj({ test: String }).test.toUpperCase()
```